### PR TITLE
Update notebook 00_pytorch_fundamentals

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/mrdbourke/pytorch-deep-learning/blob/main/00_pytorch_fundamentals.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -107,7 +107,6 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "application/vnd.google.colaboratory.intrinsic+json": {
               "type": "string"
@@ -116,8 +115,9 @@
               "'1.10.0+cu111'"
             ]
           },
+          "execution_count": 1,
           "metadata": {},
-          "execution_count": 1
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -194,14 +194,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor(7)"
             ]
           },
+          "execution_count": 2,
           "metadata": {},
-          "execution_count": 2
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -235,14 +235,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "0"
             ]
           },
+          "execution_count": 3,
           "metadata": {},
-          "execution_count": 3
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -274,14 +274,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "7"
             ]
           },
+          "execution_count": 4,
           "metadata": {},
-          "execution_count": 4
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -316,14 +316,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([7, 7])"
             ]
           },
+          "execution_count": 5,
           "metadata": {},
-          "execution_count": 5
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -355,14 +355,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1"
             ]
           },
+          "execution_count": 6,
           "metadata": {},
-          "execution_count": 6
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -393,22 +393,22 @@
       "cell_type": "code",
       "execution_count": 7,
       "metadata": {
-        "id": "6zREV1bDTGe2",
-        "outputId": "2a6e7ceb-7eb2-422b-b006-2c6e4825272f",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "6zREV1bDTGe2",
+        "outputId": "2a6e7ceb-7eb2-422b-b006-2c6e4825272f"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.Size([2])"
             ]
           },
+          "execution_count": 7,
           "metadata": {},
-          "execution_count": 7
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -439,15 +439,15 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[ 7,  8],\n",
               "        [ 9, 10]])"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 8
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -479,14 +479,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "2"
             ]
           },
+          "execution_count": 9,
           "metadata": {},
-          "execution_count": 9
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -509,22 +509,22 @@
       "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "id": "_TL26I31TGe3",
-        "outputId": "f05ec0b6-0bc1-4381-9474-56cbe6c67139",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "_TL26I31TGe3",
+        "outputId": "f05ec0b6-0bc1-4381-9474-56cbe6c67139"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.Size([2, 2])"
             ]
           },
+          "execution_count": 10,
           "metadata": {},
-          "execution_count": 10
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -554,7 +554,6 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[[1, 2, 3],\n",
@@ -562,8 +561,9 @@
               "         [2, 4, 5]]])"
             ]
           },
+          "execution_count": 11,
           "metadata": {},
-          "execution_count": 11
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -603,14 +603,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "3"
             ]
           },
+          "execution_count": 12,
           "metadata": {},
-          "execution_count": 12
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -631,22 +631,22 @@
       "cell_type": "code",
       "execution_count": 13,
       "metadata": {
-        "id": "hdVv4iNRTGe5",
-        "outputId": "d8ac706c-020b-4926-b145-d44e41f35e90",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "hdVv4iNRTGe5",
+        "outputId": "d8ac706c-020b-4926-b145-d44e41f35e90"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.Size([1, 3, 3])"
             ]
           },
+          "execution_count": 13,
           "metadata": {},
-          "execution_count": 13
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -725,7 +725,6 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[0.4090, 0.2527, 0.8699, 0.2002],\n",
@@ -733,8 +732,9 @@
               "         [0.2281, 0.0345, 0.6734, 0.3866]]), torch.float32)"
             ]
           },
+          "execution_count": 14,
           "metadata": {},
-          "execution_count": 14
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -756,11 +756,7 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Create a random tensor of size (224, 224, 3)\n",
-        "random_image_size_tensor = torch.rand(size=(224, 224, 3))\n",
-        "random_image_size_tensor.shape, random_image_size_tensor.ndim"
-      ],
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -768,18 +764,22 @@
         "id": "xMF_NUp3Ym__",
         "outputId": "8346b853-0b1e-481a-d9ee-a410ee21bab0"
       },
-      "execution_count": 15,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(torch.Size([224, 224, 3]), 3)"
             ]
           },
+          "execution_count": 15,
           "metadata": {},
-          "execution_count": 15
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Create a random tensor of size (224, 224, 3)\n",
+        "random_image_size_tensor = torch.rand(size=(224, 224, 3))\n",
+        "random_image_size_tensor.shape, random_image_size_tensor.ndim"
       ]
     },
     {
@@ -811,7 +811,6 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[0., 0., 0., 0.],\n",
@@ -819,8 +818,9 @@
               "         [0., 0., 0., 0.]]), torch.float32)"
             ]
           },
+          "execution_count": 16,
           "metadata": {},
-          "execution_count": 16
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -831,26 +831,25 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We can do the same to create a tensor of all ones except using [`torch.ones()` ](https://pytorch.org/docs/stable/generated/torch.ones.html) instead."
-      ],
       "metadata": {
         "id": "WDQBZJRUZWTN"
-      }
+      },
+      "source": [
+        "We can do the same to create a tensor of all ones except using [`torch.ones()` ](https://pytorch.org/docs/stable/generated/torch.ones.html) instead."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 17,
       "metadata": {
-        "id": "HRe6sSXiTGe6",
-        "outputId": "3f45b0b8-7f65-423d-c664-f5b5f7866fd2",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "HRe6sSXiTGe6",
+        "outputId": "3f45b0b8-7f65-423d-c664-f5b5f7866fd2"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[1., 1., 1., 1.],\n",
@@ -858,8 +857,9 @@
               "         [1., 1., 1., 1.]]), torch.float32)"
             ]
           },
+          "execution_count": 17,
           "metadata": {},
-          "execution_count": 17
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -870,6 +870,26 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Note**: We've seen how to use `torch.rand`, `torch.zeros`, and `torch.ones` with the `size` parameter, but we can also call them without setting an explicit `size` parameter and just pass the shape we want as integers. For example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "another_random_tensor = torch.rand(224, 224, 3)\n",
+        "random_image_size_tensor.shape, random_image_size_tensor.ndim"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hib1NYrSarL2"
+      },
       "source": [
         "### Creating a range and tensors like\n",
         "\n",
@@ -883,10 +903,7 @@
         "* `step` = how many steps in between each value (e.g. 1)\n",
         "\n",
         "> **Note:** In Python, you can use `range()` to create a range. However in PyTorch, `torch.range()` is deprecated and may show an error in the future."
-      ],
-      "metadata": {
-        "id": "hib1NYrSarL2"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -900,22 +917,22 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:2: UserWarning: torch.range is deprecated and will be removed in a future release because its behavior is inconsistent with Python's range builtin. Instead, use torch.arange, which produces values in [start, end).\n",
             "  \n"
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])"
             ]
           },
+          "execution_count": 18,
           "metadata": {},
-          "execution_count": 18
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -929,16 +946,16 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "i-bXf0Ugbh-D"
+      },
       "source": [
         "Sometimes you might want one tensor of a certain type with the same shape as another tensor.\n",
         "\n",
         "For example, a tensor of all zeros with the same shape as a previous tensor. \n",
         "\n",
         "To do so you can use [`torch.zeros_like(input)`](https://pytorch.org/docs/stable/generated/torch.zeros_like.html) or [`torch.ones_like(input)`](https://pytorch.org/docs/1.9.1/generated/torch.ones_like.html) which return a tensor filled with zeros or ones in the same shape as the `input` respectively."
-      ],
-      "metadata": {
-        "id": "i-bXf0Ugbh-D"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -952,14 +969,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])"
             ]
           },
+          "execution_count": 19,
           "metadata": {},
-          "execution_count": 19
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1025,14 +1042,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(torch.Size([3]), torch.float32, device(type='cpu'))"
             ]
           },
+          "execution_count": 20,
           "metadata": {},
-          "execution_count": 20
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1047,6 +1064,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "MhP8kzDfe_ty"
+      },
       "source": [
         "Aside from shape issues (tensor shapes don't match up), two of the other most common issues you'll come across in PyTorch are datatype and device issues.\n",
         "\n",
@@ -1057,10 +1077,7 @@
         "We'll see more of this device talk later on.\n",
         "\n",
         "For now let's create a tensor with `dtype=torch.float16`."
-      ],
-      "metadata": {
-        "id": "MhP8kzDfe_ty"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -1074,14 +1091,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.float16"
             ]
           },
+          "execution_count": 21,
           "metadata": {},
-          "execution_count": 21
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1121,8 +1138,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "tensor([[0.7799, 0.8140, 0.0893, 0.2062],\n",
             "        [0.7525, 0.3845, 0.8207, 0.4587],\n",
@@ -1146,13 +1163,13 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "45K-E5uPg6cj"
+      },
       "source": [
         "> **Note:** When you run into issues in PyTorch, it's very often one to do with one of the three attributes above. So when the error messages show up, sing yourself a little song called \"what, what, where\": \n",
         "  * \"*what shape are my tensors? what datatype are they and where are they stored? what shape, what datatype, where where where*\""
-      ],
-      "metadata": {
-        "id": "45K-E5uPg6cj"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1203,14 +1220,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([11, 12, 13])"
             ]
           },
+          "execution_count": 23,
           "metadata": {},
-          "execution_count": 23
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1231,14 +1248,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([10, 20, 30])"
             ]
           },
+          "execution_count": 24,
           "metadata": {},
-          "execution_count": 24
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1248,12 +1265,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Notice how the tensor values above didn't end up being `tensor([110, 120, 130])`, this is because the values inside the tensor don't change unless they're reassigned."
-      ],
       "metadata": {
         "id": "-1VEHnuRkn8Q"
-      }
+      },
+      "source": [
+        "Notice how the tensor values above didn't end up being `tensor([110, 120, 130])`, this is because the values inside the tensor don't change unless they're reassigned."
+      ]
     },
     {
       "cell_type": "code",
@@ -1267,14 +1284,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3])"
             ]
           },
+          "execution_count": 25,
           "metadata": {},
-          "execution_count": 25
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1284,12 +1301,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Let's subtract a number and this time we'll reassign the `tensor` variable. "
-      ],
       "metadata": {
         "id": "VYvqGpUTk1o6"
-      }
+      },
+      "source": [
+        "Let's subtract a number and this time we'll reassign the `tensor` variable. "
+      ]
     },
     {
       "cell_type": "code",
@@ -1303,14 +1320,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([-9, -8, -7])"
             ]
           },
+          "execution_count": 26,
           "metadata": {},
-          "execution_count": 26
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1331,14 +1348,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3])"
             ]
           },
+          "execution_count": 27,
           "metadata": {},
-          "execution_count": 27
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1349,12 +1366,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "PyTorch also has a bunch of built-in functions like [`torch.mul()`](https://pytorch.org/docs/stable/generated/torch.mul.html#torch.mul) (short for multiplcation) and [`torch.add()`](https://pytorch.org/docs/stable/generated/torch.add.html) to perform basic operations. "
-      ],
       "metadata": {
         "id": "CYXDoIOzk-6I"
-      }
+      },
+      "source": [
+        "PyTorch also has a bunch of built-in functions like [`torch.mul()`](https://pytorch.org/docs/stable/generated/torch.mul.html#torch.mul) (short for multiplcation) and [`torch.add()`](https://pytorch.org/docs/stable/generated/torch.add.html) to perform basic operations. "
+      ]
     },
     {
       "cell_type": "code",
@@ -1368,19 +1385,19 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([10, 20, 30])"
             ]
           },
+          "execution_count": 28,
           "metadata": {},
-          "execution_count": 28
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Can also use torch functions\n",
-        "torch.multiply(tensor, 10)"
+        "torch.mul(tensor, 10)"
       ]
     },
     {
@@ -1395,14 +1412,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3])"
             ]
           },
+          "execution_count": 29,
           "metadata": {},
-          "execution_count": 29
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1412,12 +1429,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "However, it's more common to use the operator symbols like `*` instead of `torch.mul()`"
-      ],
       "metadata": {
         "id": "70UNL33AlVQq"
-      }
+      },
+      "source": [
+        "However, it's more common to use the operator symbols like `*` instead of `torch.mul()`"
+      ]
     },
     {
       "cell_type": "code",
@@ -1431,8 +1448,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "tensor([1, 2, 3]) * tensor([1, 2, 3])\n",
             "Equals: tensor([1, 4, 9])\n"
@@ -1486,24 +1503,26 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.Size([3])"
             ]
           },
+          "execution_count": 31,
           "metadata": {},
-          "execution_count": 31
+          "output_type": "execute_result"
         }
       ],
       "source": [
-        "import torch\n",
         "tensor = torch.tensor([1, 2, 3])\n",
         "tensor.shape"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "VUAZ3_b0vOKv"
+      },
       "source": [
         "The difference between element-wise multiplication and matrix multiplication is the addition of values.\n",
         "\n",
@@ -1513,17 +1532,11 @@
         "| ----- | ----- | ----- |\n",
         "| **Element-wise multiplication** | `[1*1, 2*2, 3*3]` = `[1, 4, 9]` | `tensor * tensor` |\n",
         "| **Matrix multiplication** | `[1*1 + 2*2 + 3*3]` = `[14]` | `tensor.matmul(tensor)` |\n"
-      ],
-      "metadata": {
-        "id": "VUAZ3_b0vOKv"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Element-wise matrix mutlication\n",
-        "tensor * tensor"
-      ],
+      "execution_count": 32,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1531,18 +1544,21 @@
         "id": "i42gkUeHvI_1",
         "outputId": "18a630ce-bb56-4c40-81b4-9fdbb2ed7a4f"
       },
-      "execution_count": 32,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 4, 9])"
             ]
           },
+          "execution_count": 32,
           "metadata": {},
-          "execution_count": 32
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# Element-wise matrix mutlication\n",
+        "tensor * tensor"
       ]
     },
     {
@@ -1557,14 +1573,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor(14)"
             ]
           },
+          "execution_count": 33,
           "metadata": {},
-          "execution_count": 33
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1584,14 +1600,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor(14)"
             ]
           },
+          "execution_count": 34,
           "metadata": {},
-          "execution_count": 34
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1601,14 +1617,14 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "obbginUMv43A"
+      },
       "source": [
         "You can do matrix multiplication by hand but it's not recommended.\n",
         "\n",
         "The in-built `torch.matmul()` method is faster."
-      ],
-      "metadata": {
-        "id": "obbginUMv43A"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -1622,8 +1638,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "CPU times: user 146 µs, sys: 38 µs, total: 184 µs\n",
             "Wall time: 227 µs\n"
@@ -1642,10 +1658,7 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "%%time\n",
-        "torch.matmul(tensor, tensor)"
-      ],
+      "execution_count": 36,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1653,26 +1666,29 @@
         "id": "vVWiKB0KwH74",
         "outputId": "fce58235-5c09-49ec-f34b-a90e5640281e"
       },
-      "execution_count": 36,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "CPU times: user 27 µs, sys: 7 µs, total: 34 µs\n",
             "Wall time: 36.7 µs\n"
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor(14)"
             ]
           },
+          "execution_count": 36,
           "metadata": {},
-          "execution_count": 36
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "%%time\n",
+        "torch.matmul(tensor, tensor)"
       ]
     },
     {
@@ -1699,9 +1715,9 @@
       },
       "outputs": [
         {
-          "output_type": "error",
           "ename": "RuntimeError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
@@ -1725,6 +1741,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "HNA6MZEFxWVt"
+      },
       "source": [
         "We can make matrix multiplication work between `tensor_A` and `tensor_B` by making their inner dimensions match.\n",
         "\n",
@@ -1735,18 +1754,11 @@
         "* `tensor.T` - where `tensor` is the desired tensor to transpose.\n",
         "\n",
         "Let's try the latter."
-      ],
-      "metadata": {
-        "id": "HNA6MZEFxWVt"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# View tensor_A and tensor_B\n",
-        "print(tensor_A)\n",
-        "print(tensor_B)"
-      ],
+      "execution_count": 38,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1754,11 +1766,10 @@
         "id": "lUqgaANiy1wq",
         "outputId": "e48bbf0c-8008-434e-d372-caa658b2f36b"
       },
-      "execution_count": 38,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "tensor([[1., 2.],\n",
             "        [3., 4.],\n",
@@ -1768,15 +1779,16 @@
             "        [ 9., 12.]])\n"
           ]
         }
+      ],
+      "source": [
+        "# View tensor_A and tensor_B\n",
+        "print(tensor_A)\n",
+        "print(tensor_B)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# View tensor_A and tensor_B.T\n",
-        "print(tensor_A)\n",
-        "print(tensor_B.T)"
-      ],
+      "execution_count": 39,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1784,11 +1796,10 @@
         "id": "DveqxO7iy_Fi",
         "outputId": "1bd2e85b-ea4d-4948-c408-8eb46ef3534c"
       },
-      "execution_count": 39,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "tensor([[1., 2.],\n",
             "        [3., 4.],\n",
@@ -1797,6 +1808,11 @@
             "        [10., 11., 12.]])\n"
           ]
         }
+      ],
+      "source": [
+        "# View tensor_A and tensor_B.T\n",
+        "print(tensor_A)\n",
+        "print(tensor_B.T)"
       ]
     },
     {
@@ -1811,8 +1827,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Original shapes: tensor_A = torch.Size([3, 2]), tensor_B = torch.Size([3, 2])\n",
             "\n",
@@ -1834,7 +1850,7 @@
         "# The operation works when tensor_B is transposed\n",
         "print(f\"Original shapes: tensor_A = {tensor_A.shape}, tensor_B = {tensor_B.shape}\\n\")\n",
         "print(f\"New shapes: tensor_A = {tensor_A.shape} (same as above), tensor_B.T = {tensor_B.T.shape}\\n\")\n",
-        "print(f\"Multiplying: {tensor_A.shape} * {tensor_B.T.shape} <- inner dimensions match\\n\")\n",
+        "print(f\"Multiplying: {tensor_A.shape} @ {tensor_B.T.shape} <- inner dimensions match\\n\")\n",
         "print(\"Output:\\n\")\n",
         "output = torch.matmul(tensor_A, tensor_B.T)\n",
         "print(output) \n",
@@ -1843,26 +1859,25 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can also use [`torch.mm()`](https://pytorch.org/docs/stable/generated/torch.mm.html) which is a short for `torch.matmul()`."
-      ],
       "metadata": {
         "id": "MfcFEqfLjN24"
-      }
+      },
+      "source": [
+        "You can also use [`torch.mm()`](https://pytorch.org/docs/stable/generated/torch.mm.html) which is a short for `torch.matmul()`."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 41,
       "metadata": {
-        "id": "x3rJvW_TTGe_",
-        "outputId": "2c501972-20bf-4a83-ad4a-b5f1b2424097",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "x3rJvW_TTGe_",
+        "outputId": "2c501972-20bf-4a83-ad4a-b5f1b2424097"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[ 27.,  30.,  33.],\n",
@@ -1870,8 +1885,9 @@
               "        [ 95., 106., 117.]])"
             ]
           },
+          "execution_count": 41,
           "metadata": {},
-          "execution_count": 41
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1881,6 +1897,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "bXKozI4T0hFi"
+      },
       "source": [
         "Without the transpose, the rules of matrix mulitplication aren't fulfilled and we get an error like above.\n",
         "\n",
@@ -1892,13 +1911,13 @@
         "\n",
         "> **Note:** A matrix multiplication like this is also referred to as the [**dot product**](https://www.mathsisfun.com/algebra/vectors-dot-product.html) of two matrices.\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "bXKozI4T0hFi"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "hA64Z4DmkB31"
+      },
       "source": [
         "Neural networks are full of matrix multiplications and dot products.\n",
         "\n",
@@ -1922,10 +1941,7 @@
         "Try changing the values of `in_features` and `out_features` below and see what happens.\n",
         "\n",
         "Do you notice anything to do with the shapes?"
-      ],
-      "metadata": {
-        "id": "hA64Z4DmkB31"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -1939,8 +1955,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Input shape: torch.Size([3, 2])\n",
             "\n",
@@ -1968,15 +1984,18 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "> **Question:** What happens if you change `in_features` from 2 to 3 above? Does it error? How could you change the shape of the input (`x`) to accomodate to the error? Hint: what did we have to do to `tensor_B` above?"
-      ],
       "metadata": {
         "id": "zIGrP5j1pN7j"
-      }
+      },
+      "source": [
+        "> **Question:** What happens if you change `in_features` from 2 to 3 above? Does it error? How could you change the shape of the input (`x`) to accomodate to the error? Hint: what did we have to do to `tensor_B` above?"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "EPNF0nMWoGEj"
+      },
       "source": [
         "If you've never done it before, matrix multiplication can be a confusing topic at first.\n",
         "\n",
@@ -1987,10 +2006,7 @@
         "![matrix multiplication is all you need](https://raw.githubusercontent.com/mrdbourke/pytorch-deep-learning/main/images/00_matrix_multiplication_is_all_you_need.jpeg)\n",
         "\n",
         "*When you start digging into neural network layers and building your own, you'll find matrix multiplications everywhere. **Source:** https://marksaroufim.substack.com/p/working-class-deep-learner*"
-      ],
-      "metadata": {
-        "id": "EPNF0nMWoGEj"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2020,14 +2036,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([ 0, 10, 20, 30, 40, 50, 60, 70, 80, 90])"
             ]
           },
+          "execution_count": 43,
           "metadata": {},
-          "execution_count": 43
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2038,12 +2054,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now let's perform some aggregation."
-      ],
       "metadata": {
         "id": "-J-wfMdlsEco"
-      }
+      },
+      "source": [
+        "Now let's perform some aggregation."
+      ]
     },
     {
       "cell_type": "code",
@@ -2057,8 +2073,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Minimum: 0\n",
             "Maximum: 90\n",
@@ -2077,14 +2093,14 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JHoKpsg3sKQE"
+      },
       "source": [
         "> **Note:** You may find some methods such as `torch.mean()` require tensors to be in `torch.float32` (the most common) or another specific datatype, otherwise the operation will fail. \n",
         "\n",
         "You can also do the same as above with `torch` methods."
-      ],
-      "metadata": {
-        "id": "JHoKpsg3sKQE"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -2098,14 +2114,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor(90), tensor(0), tensor(45.), tensor(450))"
             ]
           },
+          "execution_count": 45,
           "metadata": {},
-          "execution_count": 45
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2137,8 +2153,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Tensor: tensor([10, 20, 30, 40, 50, 60, 70, 80, 90])\n",
             "Index where max value occurs: 8\n",
@@ -2187,14 +2203,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "torch.float32"
             ]
           },
+          "execution_count": 47,
           "metadata": {},
-          "execution_count": 47
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2205,13 +2221,13 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "jR30FHEc92of"
+      },
       "source": [
         "Now we'll create another tensor the same as before but change its datatype to `torch.float16`.\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "jR30FHEc92of"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -2225,14 +2241,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([10., 20., 30., 40., 50., 60., 70., 80., 90.], dtype=torch.float16)"
             ]
           },
+          "execution_count": 48,
           "metadata": {},
-          "execution_count": 48
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2243,12 +2259,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "And we can do something similar to make a `torch.int8` tensor."
-      ],
       "metadata": {
         "id": "ndVlKJZ4-7_5"
-      }
+      },
+      "source": [
+        "And we can do something similar to make a `torch.int8` tensor."
+      ]
     },
     {
       "cell_type": "code",
@@ -2262,14 +2278,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([10, 20, 30, 40, 50, 60, 70, 80, 90], dtype=torch.int8)"
             ]
           },
+          "execution_count": 49,
           "metadata": {},
-          "execution_count": 49
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2280,14 +2296,14 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "44GxVabar-xe"
+      },
       "source": [
         "> **Note:** Different datatypes can be confusing to begin with. But think of it like this, the lower the number (e.g. 32, 16, 8), the less precise a computer stores the value. And with a lower amount of storage, this generally results in faster computation and a smaller overall model. Mobile-based neural networks often operate with 8-bit integers, smaller and faster to run but less accurate than their float32 counterparts. For more on this, I'd read up about [precision in computing](https://en.wikipedia.org/wiki/Precision_(computer_science)).\n",
         "\n",
         "> **Exercise:** So far we've covered a fair few tensor methods but there's a bunch more in the [`torch.Tensor` documentation](https://pytorch.org/docs/stable/tensors.html), I'd recommend spending 10-minutes scrolling through and looking into any that catch your eye. Click on them and then write them out in code yourself to see what happens."
-      ],
-      "metadata": {
-        "id": "44GxVabar-xe"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2331,31 +2347,30 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([1., 2., 3., 4., 5., 6., 7.]), torch.Size([7]))"
             ]
           },
+          "execution_count": 50,
           "metadata": {},
-          "execution_count": 50
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Create a tensor\n",
-        "import torch\n",
         "x = torch.arange(1., 8.)\n",
         "x, x.shape"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now let's add an extra dimension with `torch.reshape()`. "
-      ],
       "metadata": {
         "id": "3_VarMO9CoT8"
-      }
+      },
+      "source": [
+        "Now let's add an extra dimension with `torch.reshape()`. "
+      ]
     },
     {
       "cell_type": "code",
@@ -2369,14 +2384,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[1., 2., 3., 4., 5., 6., 7.]]), torch.Size([1, 7]))"
             ]
           },
+          "execution_count": 51,
           "metadata": {},
-          "execution_count": 51
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2387,33 +2402,33 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We can also change the view with `torch.view()`."
-      ],
       "metadata": {
         "id": "tig5xm0jCxuU"
-      }
+      },
+      "source": [
+        "We can also change the view with `torch.view()`."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 52,
       "metadata": {
-        "id": "WDN2BNe5TGfB",
-        "outputId": "3df1b0d6-2548-4ecc-ca25-0c4e28a6e536",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "WDN2BNe5TGfB",
+        "outputId": "3df1b0d6-2548-4ecc-ca25-0c4e28a6e536"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[1., 2., 3., 4., 5., 6., 7.]]), torch.Size([1, 7]))"
             ]
           },
+          "execution_count": 52,
           "metadata": {},
-          "execution_count": 52
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2425,35 +2440,35 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "m8joAaUEC2NX"
+      },
       "source": [
         "Remember though, changing the view of a tensor with `torch.view()` really only creates a new view of the *same* tensor.\n",
         "\n",
         "So changing the view changes the original tensor too. "
-      ],
-      "metadata": {
-        "id": "m8joAaUEC2NX"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 53,
       "metadata": {
-        "id": "2DxURVvXTGfC",
-        "outputId": "668d194d-dd0a-4db1-da00-9c3fd8849186",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "2DxURVvXTGfC",
+        "outputId": "668d194d-dd0a-4db1-da00-9c3fd8849186"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[5., 2., 3., 4., 5., 6., 7.]]), tensor([5., 2., 3., 4., 5., 6., 7.]))"
             ]
           },
+          "execution_count": 53,
           "metadata": {},
-          "execution_count": 53
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2464,12 +2479,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "If we wanted to stack our new tensor on top of itself five times, we could do so with `torch.stack()`."
-      ],
       "metadata": {
         "id": "YxnqDBlpDDJ_"
-      }
+      },
+      "source": [
+        "If we wanted to stack our new tensor on top of itself five times, we could do so with `torch.stack()`."
+      ]
     },
     {
       "cell_type": "code",
@@ -2483,7 +2498,6 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[5., 2., 3., 4., 5., 6., 7.],\n",
@@ -2492,8 +2506,9 @@
               "        [5., 2., 3., 4., 5., 6., 7.]])"
             ]
           },
+          "execution_count": 54,
           "metadata": {},
-          "execution_count": 54
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2504,14 +2519,14 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ET56QzNHDuOI"
+      },
       "source": [
         "How about removing all single dimensions from a tensor?\n",
         "\n",
         "To do so you can use `torch.squeeze()` (I remember this as *squeezing* the tensor to only have dimensions over 1)."
-      ],
-      "metadata": {
-        "id": "ET56QzNHDuOI"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -2525,8 +2540,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Previous tensor: tensor([[5., 2., 3., 4., 5., 6., 7.]])\n",
             "Previous shape: torch.Size([1, 7])\n",
@@ -2548,12 +2563,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "And to do the reverse of `torch.squeeze()` you can use `torch.unsqueeze()` to add a dimension value of 1 at a specific index."
-      ],
       "metadata": {
         "id": "acjDLk8WD8NC"
-      }
+      },
+      "source": [
+        "And to do the reverse of `torch.squeeze()` you can use `torch.unsqueeze()` to add a dimension value of 1 at a specific index."
+      ]
     },
     {
       "cell_type": "code",
@@ -2567,8 +2582,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Previous tensor: tensor([5., 2., 3., 4., 5., 6., 7.])\n",
             "Previous shape: torch.Size([7])\n",
@@ -2590,27 +2605,27 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can also rearrange the order of axes values with `torch.permute(input, dims)`, where the `input` gets turned into a *view* with new `dims`."
-      ],
       "metadata": {
         "id": "R9DuJzXgFbM5"
-      }
+      },
+      "source": [
+        "You can also rearrange the order of axes values with `torch.permute(input, dims)`, where the `input` gets turned into a *view* with new `dims`."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 57,
       "metadata": {
-        "id": "fCRGCX8DTGfC",
-        "outputId": "6853328b-a1cf-4470-f366-106a231a189c",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "fCRGCX8DTGfC",
+        "outputId": "6853328b-a1cf-4470-f366-106a231a189c"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Previous shape: torch.Size([224, 224, 3])\n",
             "New shape: torch.Size([3, 224, 224])\n"
@@ -2630,12 +2645,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "> **Note**: Because permuting returns a *view* (shares the same data as the original), the values in the permuted tensor will be the same as the original tensor and if you change the values in the view, it will change the values of the original."
-      ],
       "metadata": {
         "id": "06LKaFemGBoE"
-      }
+      },
+      "source": [
+        "> **Note**: Because permuting returns a *view* (shares the same data as the original), the values in the permuted tensor will be the same as the original tensor and if you change the values in the view, it will change the values of the original."
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2656,15 +2671,14 @@
       "cell_type": "code",
       "execution_count": 58,
       "metadata": {
-        "id": "oSXzdxCQTGfD",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "oSXzdxCQTGfD",
         "outputId": "05a72c08-5f8c-433a-cd31-46065686f825"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([[[1, 2, 3],\n",
@@ -2672,40 +2686,40 @@
               "          [7, 8, 9]]]), torch.Size([1, 3, 3]))"
             ]
           },
+          "execution_count": 58,
           "metadata": {},
-          "execution_count": 58
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Create a tensor \n",
-        "import torch\n",
         "x = torch.arange(1, 10).reshape(1, 3, 3)\n",
         "x, x.shape"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Indexing values goes outer dimension -> inner dimension (check out the square brackets)."
-      ],
       "metadata": {
         "id": "xQG5krnKG43B"
-      }
+      },
+      "source": [
+        "Indexing values goes outer dimension -> inner dimension (check out the square brackets)."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 59,
       "metadata": {
-        "id": "zv_Z3IAzTGfD",
-        "outputId": "cf6c0936-7600-4af4-9b6f-f6b8ac9b4c05",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "zv_Z3IAzTGfD",
+        "outputId": "cf6c0936-7600-4af4-9b6f-f6b8ac9b4c05"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "First square bracket:\n",
             "tensor([[1, 2, 3],\n",
@@ -2725,33 +2739,33 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "You can also use `:` to specify \"all values in this dimension\" and then use a comma (`,`) to add another dimension."
-      ],
       "metadata": {
         "id": "XaLjaIFxHe89"
-      }
+      },
+      "source": [
+        "You can also use `:` to specify \"all values in this dimension\" and then use a comma (`,`) to add another dimension."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 60,
       "metadata": {
-        "id": "gCT09pqeTGfD",
-        "outputId": "a91f9b73-f8f0-476a-9c69-fcd03b042f6b",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "gCT09pqeTGfD",
+        "outputId": "a91f9b73-f8f0-476a-9c69-fcd03b042f6b"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[1, 2, 3]])"
             ]
           },
+          "execution_count": 60,
           "metadata": {},
-          "execution_count": 60
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2763,22 +2777,22 @@
       "cell_type": "code",
       "execution_count": 61,
       "metadata": {
-        "id": "dwDx_gMsTGfD",
-        "outputId": "8165cfd9-a88d-4212-8c45-1eb84ef5be83",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "dwDx_gMsTGfD",
+        "outputId": "8165cfd9-a88d-4212-8c45-1eb84ef5be83"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[2, 5, 8]])"
             ]
           },
+          "execution_count": 61,
           "metadata": {},
-          "execution_count": 61
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2790,22 +2804,22 @@
       "cell_type": "code",
       "execution_count": 62,
       "metadata": {
-        "id": "xiw3_1E3TGfD",
-        "outputId": "12fa4749-cf52-4e88-c2c0-44d26aeb633c",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "xiw3_1E3TGfD",
+        "outputId": "12fa4749-cf52-4e88-c2c0-44d26aeb633c"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([5])"
             ]
           },
+          "execution_count": 62,
           "metadata": {},
-          "execution_count": 62
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2817,22 +2831,22 @@
       "cell_type": "code",
       "execution_count": 63,
       "metadata": {
-        "id": "XFVEgrKhTGfD",
-        "outputId": "69eadeb9-11b3-4b48-cb95-0b3305c1274c",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "XFVEgrKhTGfD",
+        "outputId": "69eadeb9-11b3-4b48-cb95-0b3305c1274c"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3])"
             ]
           },
+          "execution_count": 63,
           "metadata": {},
-          "execution_count": 63
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2842,12 +2856,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Indexing can be quite confusing to begin with, especially with larger tensors (I still have to try indexing multiple times to get it right). But with a bit of practice and following the data explorer's motto (***visualize, visualize, visualize***), you'll start to get the hang of it."
-      ],
       "metadata": {
         "id": "6Ik0r11RIxtm"
-      }
+      },
+      "source": [
+        "Indexing can be quite confusing to begin with, especially with larger tensors (I still have to try indexing multiple times to get it right). But with a bit of practice and following the data explorer's motto (***visualize, visualize, visualize***), you'll start to get the hang of it."
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2878,20 +2892,19 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(array([1., 2., 3., 4., 5., 6., 7.]),\n",
               " tensor([1., 2., 3., 4., 5., 6., 7.], dtype=torch.float64))"
             ]
           },
+          "execution_count": 64,
           "metadata": {},
-          "execution_count": 64
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# NumPy array to tensor\n",
-        "import torch\n",
         "import numpy as np\n",
         "array = np.arange(1.0, 8.0)\n",
         "tensor = torch.from_numpy(array)\n",
@@ -2900,6 +2913,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "16JG6cONLPnO"
+      },
       "source": [
         "> **Note:** By default, NumPy arrays are created with the datatype `float64` and if you convert it to a PyTorch tensor, it'll keep the same datatype (as above). \n",
         ">\n",
@@ -2908,10 +2924,7 @@
         "> So if you want to convert your NumPy array (float64) -> PyTorch tensor (float64) -> PyTorch tensor (float32), you can use `tensor = torch.from_numpy(array).type(torch.float32)`.\n",
         "\n",
         "Because we reassigned `tensor` above, if you change the tensor, the array stays the same."
-      ],
-      "metadata": {
-        "id": "16JG6cONLPnO"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -2925,15 +2938,15 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(array([2., 3., 4., 5., 6., 7., 8.]),\n",
               " tensor([1., 2., 3., 4., 5., 6., 7.], dtype=torch.float64))"
             ]
           },
+          "execution_count": 65,
           "metadata": {},
-          "execution_count": 65
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2944,12 +2957,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "And if you want to go from PyTorch tensor to NumPy array, you can call `tensor.numpy()`."
-      ],
       "metadata": {
         "id": "geVvu1p0MTWc"
-      }
+      },
+      "source": [
+        "And if you want to go from PyTorch tensor to NumPy array, you can call `tensor.numpy()`."
+      ]
     },
     {
       "cell_type": "code",
@@ -2963,15 +2976,15 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([1., 1., 1., 1., 1., 1., 1.]),\n",
               " array([1., 1., 1., 1., 1., 1., 1.], dtype=float32))"
             ]
           },
+          "execution_count": 66,
           "metadata": {},
-          "execution_count": 66
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2983,12 +2996,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "And the same rule applies as above, if you change the original `tensor`, the new `numpy_tensor` stays the same."
-      ],
       "metadata": {
         "id": "Dt8yEV1jMfi2"
-      }
+      },
+      "source": [
+        "And the same rule applies as above, if you change the original `tensor`, the new `numpy_tensor` stays the same."
+      ]
     },
     {
       "cell_type": "code",
@@ -3002,15 +3015,15 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(tensor([2., 2., 2., 2., 2., 2., 2.]),\n",
               " array([1., 1., 1., 1., 1., 1., 1.], dtype=float32))"
             ]
           },
+          "execution_count": 67,
           "metadata": {},
-          "execution_count": 67
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3064,16 +3077,16 @@
       "cell_type": "code",
       "execution_count": 68,
       "metadata": {
-        "id": "eSwxnwEbTGfF",
-        "outputId": "73b34154-734f-496f-9b55-b6aaa137e854",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "eSwxnwEbTGfF",
+        "outputId": "73b34154-734f-496f-9b55-b6aaa137e854"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Tensor A:\n",
             "tensor([[0.8016, 0.3649, 0.6286, 0.9663],\n",
@@ -3089,7 +3102,6 @@
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[False, False, False, False],\n",
@@ -3097,13 +3109,12 @@
               "        [False, False, False, False]])"
             ]
           },
+          "execution_count": 68,
           "metadata": {},
-          "execution_count": 68
+          "output_type": "execute_result"
         }
       ],
       "source": [
-        "import torch\n",
-        "\n",
         "# Create two random tensors\n",
         "random_tensor_A = torch.rand(3, 4)\n",
         "random_tensor_B = torch.rand(3, 4)\n",
@@ -3116,6 +3127,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "nPU6mDKJnr8M"
+      },
       "source": [
         "Just as you might've expected, the tensors come out with different values.\n",
         "\n",
@@ -3126,25 +3140,22 @@
         "That's where [`torch.manual_seed(seed)`](https://pytorch.org/docs/stable/generated/torch.manual_seed.html) comes in, where `seed` is an integer (like `42` but it could be anything) that flavours the randomness.\n",
         "\n",
         "Let's try it out by creating some more *flavoured* random tensors."
-      ],
-      "metadata": {
-        "id": "nPU6mDKJnr8M"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 69,
       "metadata": {
-        "id": "sB6d1GfYTGfF",
-        "outputId": "4d11d38e-4406-4aff-9a81-cf13aa89ee5f",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "sB6d1GfYTGfF",
+        "outputId": "4d11d38e-4406-4aff-9a81-cf13aa89ee5f"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Tensor C:\n",
             "tensor([[0.8823, 0.9150, 0.3829, 0.9593],\n",
@@ -3160,7 +3171,6 @@
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([[True, True, True, True],\n",
@@ -3168,22 +3178,20 @@
               "        [True, True, True, True]])"
             ]
           },
+          "execution_count": 69,
           "metadata": {},
-          "execution_count": 69
+          "output_type": "execute_result"
         }
       ],
       "source": [
-        "import torch\n",
-        "import random\n",
-        "\n",
-        "# # Set the random seed\n",
+        "## Set the random seed\n",
         "RANDOM_SEED=42 # try changing this to different values and see what happens to the numbers below\n",
         "torch.manual_seed(seed=RANDOM_SEED) \n",
         "random_tensor_C = torch.rand(3, 4)\n",
         "\n",
         "# Have to reset the seed every time a new rand() is called \n",
         "# Without this, tensor_D would be different to tensor_C \n",
-        "torch.random.manual_seed(seed=RANDOM_SEED) # try commenting this line out and seeing what happens\n",
+        "torch.manual_seed(seed=RANDOM_SEED) # try commenting this line out and seeing what happens\n",
         "random_tensor_D = torch.rand(3, 4)\n",
         "\n",
         "print(f\"Tensor C:\\n{random_tensor_C}\\n\")\n",
@@ -3194,6 +3202,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "uct53Xr5QRC_"
+      },
       "source": [
         "Nice!\n",
         "\n",
@@ -3202,10 +3213,7 @@
         "> **Resource:** What we've just covered only scratches the surface of reproducibility in PyTorch. For more, on reproducbility in general and random seeds, I'd checkout:\n",
         "> * [The PyTorch reproducibility documentation](https://pytorch.org/docs/stable/notes/randomness.html) (a good exericse would be to read through this for 10-minutes and even if you don't understand it now, being aware of it is important).\n",
         "> * [The Wikipedia random seed page](https://en.wikipedia.org/wiki/Random_seed) (this'll give a good overview of random seeds and pseudorandomness in general)."
-      ],
-      "metadata": {
-        "id": "uct53Xr5QRC_"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3233,6 +3241,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "0UiR6QpoYQH_"
+      },
       "source": [
         "\n",
         "### 1. Getting a GPU\n",
@@ -3253,16 +3264,11 @@
         "\n",
         "To check if you've got access to a Nvidia GPU, you can run `!nvidia-smi` where the `!` (also called bang) means \"run this on the command line\".\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "0UiR6QpoYQH_"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!nvidia-smi"
-      ],
+      "execution_count": 70,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -3270,11 +3276,10 @@
         "id": "vEMcO-9zYc-w",
         "outputId": "77405db7-3494-4add-cfc7-8415e52a0412"
       },
-      "execution_count": 70,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Thu Feb 10 02:09:18 2022       \n",
             "+-----------------------------------------------------------------------------+\n",
@@ -3298,10 +3303,16 @@
             "+-----------------------------------------------------------------------------+\n"
           ]
         }
+      ],
+      "source": [
+        "!nvidia-smi"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "HvkB9p5zYf8E"
+      },
       "source": [
         "If you don't have a Nvidia GPU accessible, the above will output something like:\n",
         "\n",
@@ -3335,13 +3346,13 @@
         "|  No running processes found                                                 |\n",
         "+-----------------------------------------------------------------------------+\n",
         "```"
-      ],
-      "metadata": {
-        "id": "HvkB9p5zYf8E"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "UvibZ6e0YcDk"
+      },
       "source": [
         "\n",
         "\n",
@@ -3354,10 +3365,7 @@
         "Rather than talk about it, let's try it out.\n",
         "\n",
         "You can test if PyTorch has access to a GPU using [`torch.cuda.is_available()`](https://pytorch.org/docs/stable/generated/torch.cuda.is_available.html#torch.cuda.is_available).\n"
-      ],
-      "metadata": {
-        "id": "UvibZ6e0YcDk"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -3371,24 +3379,26 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "True"
             ]
           },
+          "execution_count": 71,
           "metadata": {},
-          "execution_count": 71
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Check for GPU\n",
-        "import torch\n",
         "torch.cuda.is_available()"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "jedZcx2PZFpL"
+      },
       "source": [
         "If the above outputs `True`, PyTorch can see and use the GPU, if it outputs `False`, it can't see the GPU and in that case, you'll have to go back through the installation steps.\n",
         "\n",
@@ -3397,25 +3407,21 @@
         "That way, if you or someone decides to run your code, it'll work regardless of the computing device they're using. \n",
         "\n",
         "Let's create a `device` variable to store what kind of device is available."
-      ],
-      "metadata": {
-        "id": "jedZcx2PZFpL"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 72,
       "metadata": {
-        "id": "j92HBCKB7rYa",
-        "outputId": "8cca1643-645c-4b67-f1f5-37066f6b9549",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 35
-        }
+        },
+        "id": "j92HBCKB7rYa",
+        "outputId": "8cca1643-645c-4b67-f1f5-37066f6b9549"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "application/vnd.google.colaboratory.intrinsic+json": {
               "type": "string"
@@ -3424,8 +3430,9 @@
               "'cuda'"
             ]
           },
+          "execution_count": 72,
           "metadata": {},
-          "execution_count": 72
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3436,6 +3443,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "FjFyPP2WaCch"
+      },
       "source": [
         "If the above output `\"cuda\"` it means we can set all of our PyTorch code to use the available CUDA device (a GPU) and if it output `\"cpu\"`, our PyTorch code will stick with the CPU.\n",
         "\n",
@@ -3444,31 +3454,28 @@
         "If you want to do faster computing you can use a GPU but if you want to do *much* faster computing, you can use multiple GPUs.\n",
         "\n",
         "You can count the number of GPUs PyTorch has access to using [`torch.cuda.device_count()`](https://pytorch.org/docs/stable/generated/torch.cuda.device_count.html#torch.cuda.device_count)."
-      ],
-      "metadata": {
-        "id": "FjFyPP2WaCch"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 73,
       "metadata": {
-        "id": "MArsn0DFTGfG",
-        "outputId": "de717df5-bb67-4900-805e-a6f00ad0b409",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "MArsn0DFTGfG",
+        "outputId": "de717df5-bb67-4900-805e-a6f00ad0b409"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1"
             ]
           },
+          "execution_count": 73,
           "metadata": {},
-          "execution_count": 73
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3478,12 +3485,12 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Knowing the number of GPUs PyTorch has access to is helpful incase you wanted to run a specific process on one GPU and another process on another (PyTorch also has features to let you run a process across *all* GPUs)."
-      ],
       "metadata": {
         "id": "xVNf1hiqa-gO"
-      }
+      },
+      "source": [
+        "Knowing the number of GPUs PyTorch has access to is helpful incase you wanted to run a specific process on one GPU and another process on another (PyTorch also has features to let you run a process across *all* GPUs)."
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3510,29 +3517,29 @@
       "cell_type": "code",
       "execution_count": 74,
       "metadata": {
-        "id": "FhI3srFXEHfP",
-        "outputId": "2f4f6435-fdc4-4e99-e87c-9421c2100f36",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "FhI3srFXEHfP",
+        "outputId": "2f4f6435-fdc4-4e99-e87c-9421c2100f36"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "tensor([1, 2, 3]) cpu\n"
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3], device='cuda:0')"
             ]
           },
+          "execution_count": 74,
           "metadata": {},
-          "execution_count": 74
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3566,6 +3573,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "4puyUX4Bci5D"
+      },
       "source": [
         "### 4. Moving tensors back to the CPU\n",
         "\n",
@@ -3574,27 +3584,24 @@
         "For example, you'll want to do this if you want to interact with your tensors with NumPy (NumPy does not leverage the GPU).\n",
         "\n",
         "Let's try using the [`torch.Tensor.numpy()`](https://pytorch.org/docs/stable/generated/torch.Tensor.numpy.html) method on our `tensor_on_gpu`."
-      ],
-      "metadata": {
-        "id": "4puyUX4Bci5D"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 75,
       "metadata": {
-        "id": "3ChSLJgPTGfG",
-        "outputId": "32e92f62-db28-4dc7-ce93-c2ab33229252",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 186
-        }
+        },
+        "id": "3ChSLJgPTGfG",
+        "outputId": "32e92f62-db28-4dc7-ce93-c2ab33229252"
       },
       "outputs": [
         {
-          "output_type": "error",
           "ename": "TypeError",
           "evalue": "ignored",
+          "output_type": "error",
           "traceback": [
             "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
             "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
@@ -3623,22 +3630,22 @@
       "cell_type": "code",
       "execution_count": 76,
       "metadata": {
-        "id": "gN15s-NdTGfG",
-        "outputId": "9fffb6f2-c200-4f9c-d987-d9ab5d9cba49",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "gN15s-NdTGfG",
+        "outputId": "9fffb6f2-c200-4f9c-d987-d9ab5d9cba49"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "array([1, 2, 3])"
             ]
           },
+          "execution_count": 76,
           "metadata": {},
-          "execution_count": 76
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3660,22 +3667,22 @@
       "cell_type": "code",
       "execution_count": 77,
       "metadata": {
-        "id": "S5u83PCRTGfH",
-        "outputId": "4cb931e2-7c8d-49b9-a7de-db3d3c6589b5",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "S5u83PCRTGfH",
+        "outputId": "4cb931e2-7c8d-49b9-a7de-db3d3c6589b5"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "tensor([1, 2, 3], device='cuda:0')"
             ]
           },
+          "execution_count": 77,
           "metadata": {},
-          "execution_count": 77
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -3740,12 +3747,13 @@
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
     "colab": {
       "collapsed_sections": [],
+      "include_colab_link": true,
       "name": "00_pytorch_fundamentals.ipynb",
       "provenance": [],
-      "toc_visible": true,
-      "include_colab_link": true
+      "toc_visible": true
     },
     "interpreter": {
       "hash": "3fbe1355223f7b2ffc113ba3ade6a2b520cadace5d5ec3e828c83ce02eb221bf"
@@ -3765,8 +3773,7 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.9.7"
-    },
-    "accelerator": "GPU"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
- Add note regarding implicit passing of `size` to `torch.rand`.
- Change `torch.multiply` to `torch.mul` as the cell above introduces.
- Remove redundant `import torch` lines.
- Change * to @ in the matmul example.
- Remove unused `random` import.
- Use `torch.manual_seed` instead of `torch.random.manual_seed`, as they are the same.