### PR TITLE
Update 05_pytorch_going_modular.md

### DIFF
--- a/05_pytorch_going_modular.md
+++ b/05_pytorch_going_modular.md
@@ -392,7 +392,7 @@ class TinyVGG(nn.Module):
       x = self.conv_block_2(x)
       x = self.classifier(x)
       return x
-      # return self.classifier(self.block_2(self.block_1(x))) # <- leverage the benefits of operator fusion
+      # return self.classifier(self.conv_block_2(self.conv_block_1(x))) # <- leverage the benefits of operator fusion
 ```
 
 Now instead of coding the TinyVGG model from scratch every time, we can import it using:


### PR DESCRIPTION
at the `return self.classifier(self.block_2(self.block_1(x)))`

You called the blocks `conv_block_1` and `conv_block_2`. Hence the return function leveraging the benefits of operator fusion errors when running a forward pass.  I fixed this by changing the two block names to the correct ones in return. 

It is also possible to rename both blocks to the shorter version of `block_1` and `block_2` respectively.