### PR TITLE
Fix to nn.Parameter arguments in 01_pytorch_workflow.ipynb

### DIFF
--- a/01_pytorch_workflow.ipynb
+++ b/01_pytorch_workflow.ipynb
@@ -417,14 +417,12 @@
     "    def __init__(self):\n",
     "        super().__init__() \n",
     "        self.weights = nn.Parameter(torch.randn(1, # <- start with random weights (this will get adjusted as the model learns)\n",
-    "            requires_grad=True, # <- can we update this value with gradient descent?\n",
-    "            dtype=torch.float # <- PyTorch loves float32 by default\n",
-    "        ))\n",
+    "                                                dtype=torch.float), # <- PyTorch loves float32 by default\n",
+    "                                   requires_grad=True) # <- can we update this value with gradient descent?)\n",
     "\n",
     "        self.bias = nn.Parameter(torch.randn(1, # <- start with random bias (this will get adjusted as the model learns)\n",
-    "            requires_grad=True, # <- can we update this value with gradient descent?\n",
-    "            dtype=torch.float # <- PyTorch loves float32 by default\n",
-    "        ))\n",
+    "                                            dtype=torch.float), # <- PyTorch loves float32 by default\n",
+    "                                requires_grad=True) # <- can we update this value with gradient descent?))\n",
     "\n",
     "    # Forward defines the computation in the model\n",
     "    def forward(self, x: torch.Tensor) -> torch.Tensor: # <- \"x\" is the input data (e.g. training/testing features)\n",
@@ -2472,7 +2470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The requires_grad parameter of nn.Parameter is being discussed in the video, but in the notebook it is the requires_grad parameter of the tensor that is being set.