### PR TITLE
Align torchmetrics.Accuracy() to the library stable version

### DIFF
--- a/02_pytorch_classification.ipynb
+++ b/02_pytorch_classification.ipynb
@@ -3699,7 +3699,7 @@
     "from torchmetrics import Accuracy\n",
     "\n",
     "# Setup metric and make sure it's on the target device\n",
-    "torchmetrics_accuracy = Accuracy().to(device)\n",
+    "torchmetrics_accuracy = Accuracy(task='multiclass', num_classes=4).to(device)\n",
     "\n",
     "# Calculate accuracy\n",
     "torchmetrics_accuracy(y_preds, y_blob_test)"


### PR DESCRIPTION
This aligns `torchmetrics.Accuracy()` to the actual stable version of the library. 
Indeed, it is now required to pass args `task` and `num_classes` to the instance in order for it to switch to the correct instance based on the task (eg `MulticlassAccuracy()` for multiclass problems).

This point is also referenced in https://github.com/mrdbourke/pytorch-deep-learning/discussions/200.

Hope it might be of help :)