### PR TITLE
Fix typo in exercise 02 notebook

### DIFF
--- a/extras/exercises/02_pytorch_classification_exercises.ipynb
+++ b/extras/exercises/02_pytorch_classification_exercises.ipynb
@@ -244,7 +244,7 @@
         "from torchmetrics import Accuracy\n",
         "\n",
         "## TODO: Uncomment this code to use the Accuracy function\n",
-        "# acc_fn = Accuracy(task="multiclass", num_classes=2).to(device) # send accuracy function to device\n",
+        "# acc_fn = Accuracy(task=\"multiclass\", num_classes=2).to(device) # send accuracy function to device\n",
         "# acc_fn"
       ],
       "metadata": {
@@ -508,7 +508,7 @@
         "from torchmetrics import Accuracy\n",
         "\n",
         "## TODO: uncomment the two lines below to send the accuracy function to the device\n",
-        "# acc_fn = Accuracy(task="multiclass", num_classes=4).to(device)\n",
+        "# acc_fn = Accuracy(task=\"multiclass\", num_classes=4).to(device)\n",
         "# acc_fn"
       ],
       "metadata": {


### PR DESCRIPTION
There was a typo in the json of the 02 lesson notebook. I added the escape character to the quotation marks, so that now it renders correctly.