### PR TITLE
Change Accuracy for recent versions of torchmetrics

### DIFF
--- a/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
+++ b/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
@@ -633,7 +633,7 @@
         "# Let's calculuate the accuracy\n",
         "!pip -q install torchmetrics # colab doesn't come with torchmetrics\n",
         "from torchmetrics import Accuracy\n",
-        "acc_fn = Accuracy().to(device) # send accuracy function to device\n",
+        "acc_fn = Accuracy(task="multiclass", num_classes=2).to(device) # send accuracy function to device\n",
         "acc_fn"
       ],
       "metadata": {

--- a/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
+++ b/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
@@ -633,7 +633,7 @@
         "# Let's calculate the accuracy\n",
         "!pip -q install torchmetrics # colab doesn't come with torchmetrics\n",
         "from torchmetrics import Accuracy\n",
-        "acc_fn = Accuracy(task="multiclass", num_classes=2).to(device) # send accuracy function to device\n",
+        "acc_fn = Accuracy(task=\"multiclass\", num_classes=2).to(device) # send accuracy function to device\n",
         "acc_fn"
       ],
       "metadata": {

--- a/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
+++ b/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
@@ -1057,7 +1057,7 @@
         "# Let's calculate the accuracy for when we fit our model\n",
         "!pip -q install torchmetrics # colab doesn't come with torchmetrics\n",
         "from torchmetrics import Accuracy\n",
-        "acc_fn = Accuracy(task=\"multiclass\", num_classes=4).to(device) # send accuracy function to device\n",
+        "acc_fn = Accuracy(task=\"multiclass\", num_classes=3).to(device) # send accuracy function to device\n",
         "acc_fn"
       ],
       "metadata": {

--- a/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
+++ b/extras/solutions/02_pytorch_classification_exercise_solutions.ipynb
@@ -630,7 +630,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# Let's calculuate the accuracy\n",
+        "# Let's calculate the accuracy\n",
         "!pip -q install torchmetrics # colab doesn't come with torchmetrics\n",
         "from torchmetrics import Accuracy\n",
         "acc_fn = Accuracy(task="multiclass", num_classes=2).to(device) # send accuracy function to device\n",
@@ -649,7 +649,7 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "Accuracy()"
+              "MulticlassAccuracy()"
             ]
           },
           "metadata": {},
@@ -1054,10 +1054,10 @@
     {
       "cell_type": "code",
       "source": [
-        "# Let's calculuate the accuracy for when we fit our model\n",
+        "# Let's calculate the accuracy for when we fit our model\n",
         "!pip -q install torchmetrics # colab doesn't come with torchmetrics\n",
         "from torchmetrics import Accuracy\n",
-        "acc_fn = Accuracy().to(device)\n",
+        "acc_fn = Accuracy(task=\"multiclass\", num_classes=4).to(device) # send accuracy function to device\n",
         "acc_fn"
       ],
       "metadata": {
@@ -1073,7 +1073,7 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "Accuracy()"
+              "MulticlassAccuracy()"
             ]
           },
           "metadata": {},


### PR DESCRIPTION
In recent versions of torchmetrics, the parameters should be declared explicitly.

Everything is fine in the course and [in the excercises](https://github.com/mrdbourke/pytorch-deep-learning/blob/main/extras/exercises/02_pytorch_classification_exercises.ipynb), but not in the solutions.
