### PR TITLE
Corrected : Mismatch in learning rate in description and code

### DIFF
--- a/01_pytorch_workflow.ipynb
+++ b/01_pytorch_workflow.ipynb
@@ -1922,7 +1922,7 @@
     "\n",
     "We'll have to pass the new model's parameters (`model.parameters()`) to the optimizer for it to adjust them during training. \n",
     "\n",
-    "The learning rate of `0.1` worked well before too so let's use that again.\n",
+    "The learning rate of `0.01` worked well before too so let's use that again.\n",
     "\n",
     "\n"
    ]


### PR DESCRIPTION
A learning rate = 0.01 was used in the code but it's written a learning rate = 0.1 worked well so we'll use it again.