### PR TITLE
[fix]: Fix a typo 'multiplcation'->'multiplication' in 00_pytorch_funamentals.ipynb

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -1352,12 +1352,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "CYXDoIOzk-6I"
    },
    "source": [
-    "PyTorch also has a bunch of built-in functions like [`torch.mul()`](https://pytorch.org/docs/stable/generated/torch.mul.html#torch.mul) (short for multiplcation) and [`torch.add()`](https://pytorch.org/docs/stable/generated/torch.add.html) to perform basic operations. "
+    "PyTorch also has a bunch of built-in functions like [`torch.mul()`](https://pytorch.org/docs/stable/generated/torch.mul.html#torch.mul) (short for multiplication) and [`torch.add()`](https://pytorch.org/docs/stable/generated/torch.add.html) to perform basic operations. "
    ]
   },
   {


### PR DESCRIPTION
This small PR fixes a typo multiplcation'->'multiplication' in [00_pytorch_funamentals.ipynb](https://github.com/mrdbourke/pytorch-deep-learning/blob/main/00_pytorch_fundamentals.ipynb)