### PR TITLE
Typo in "00_pytorch_fundamentals.ipynb"

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -72,7 +72,7 @@
     "| **Reproducibility** | Machine learning is very experimental and since it uses a lot of *randomness* to work, sometimes you'll want that *randomness* to not be so random. |\n",
     "| **Running tensors on GPU** | GPUs (Graphics Processing Units) make your code faster, PyTorch makes it easy to run your code on GPUs. |\n",
     "\n",
-    "## Where can can you get help?\n",
+    "## Where can you get help?\n",
     "\n",
     "All of the materials for this course [live on GitHub](https://github.com/mrdbourke/pytorch-deep-learning).\n",
     "\n",


### PR DESCRIPTION
Correct the typo 
Updated the heading from "Where can can you get help?" to "Where can you get help?"
![image](https://user-images.githubusercontent.com/38135521/232866357-0d02ecef-d530-43c4-bb61-c19a43542e86.png)
