### PR TITLE
Fix typo use of apostrophe in plural form

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -671,7 +671,7 @@
     "\n",
     "> **Note:** You might've noticed me using lowercase letters for `scalar` and `vector` and uppercase letters for `MATRIX` and `TENSOR`. This was on purpose. In practice, you'll often see scalars and vectors denoted as lowercase letters such as `y` or `a`. And matrices and tensors denoted as uppercase letters such as `X` or `W`.\n",
     ">\n",
-    "> You also might notice the names martrix and tensor used interchangably. This is common. Since in PyTorch you're often dealing with `torch.Tensor`'s (hence the tensor name), however, the shape and dimensions of what's inside will dictate what it actually is.\n",
+    "> You also might notice the names martrix and tensor used interchangably. This is common. Since in PyTorch you're often dealing with `torch.Tensor`s (hence the tensor name), however, the shape and dimensions of what's inside will dictate what it actually is.\n",
     "\n",
     "Let's summarise.\n",
     "\n",


### PR DESCRIPTION
Plural forms of words (in this case, `torch.Tensor`) [shouldn't have apostrophes](https://www.sussex.ac.uk/informatics/punctuation/apostrophe/plurals), it's usually meant for contractions or to indicate possession. I apologize in advance for any further grammar-based PRs, I'll likely group them into one larger PR if that would be more convenient. Again great tutorial just trying to clean up as I go along :)