### PR TITLE
Correct Minor Typo in "Replicating Research Papers"

### DIFF
--- a/docs/08_pytorch_paper_replicating.ipynb
+++ b/docs/08_pytorch_paper_replicating.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "A machine learning research paper is often a presentation of months of work and experiments done by some of the best machine learning teams in the world condensed into a few pages of text.\n",
     "\n",
-    "And if these experiments lead to better results in an area related to the problem you're working on, it'd be nice to them out.\n",
+    "And if these experiments lead to better results in an area related to the problem you're working on, it'd be nice to try them out.\n",
     "\n",
     "Also, replicating the work of others is a fantastic way to practice your skills.\n",
     "\n",


### PR DESCRIPTION
correct typo ("to them out" --> "to try them out")