### PR TITLE
Update 08_pytorch_paper_replicating.ipynb

### DIFF
--- a/08_pytorch_paper_replicating.ipynb
+++ b/08_pytorch_paper_replicating.ipynb
@@ -2856,7 +2856,7 @@
     "\n",
     "# Pass output of MSABlock through MLPBlock\n",
     "patched_image_through_mlp_block = mlp_block(patched_image_through_msa_block)\n",
-    "print(f\"Input shape of MLP block: {patched_image_through_mlp_block.shape}\")\n",
+    "print(f\"Input shape of MLP block: {patched_image_through_msa_block.shape}\")\n",
     "print(f\"Output shape MLP block: {patched_image_through_mlp_block.shape}\")"
    ]
   },


### PR DESCRIPTION
Input of MLP layer should be msa while printing out input and output of MLP layer