### PR TITLE
Fix grammar error in lesson 00

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -2327,7 +2327,7 @@
     "\n",
     "Why do any of these?\n",
     "\n",
-    "Because deep learning models (neural networks) are all about manipulating tensors in some way. And because of the rules of matrix multiplication, if you've got shape mismatches, you'll run into errors. These methods help you make the right elements of your tensors are mixing with the right elements of other tensors. \n",
+    "Because deep learning models (neural networks) are all about manipulating tensors in some way. And because of the rules of matrix multiplication, if you've got shape mismatches, you'll run into errors. These methods help you make sure the right elements of your tensors are mixing with the right elements of other tensors. \n",
     "\n",
     "Let's try them out.\n",
     "\n",


### PR DESCRIPTION
Hi @mrdbourke , minor grammar error in https://www.learnpytorch.io/00_pytorch_fundamentals/#reshaping-stacking-squeezing-and-unsqueezing. 

It says:

```
These methods help you make the right elements of your tensors are mixing with the right elements of other tensors
```

I think it should be:

```
These methods help you make sure the right elements of your tensors are mixing with the right elements of other tensors
```

Thanks