### PR TITLE
Update 00_pytorch_fundamentals.ipynb

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -2319,7 +2319,7 @@
     "| Method | One-line description |\n",
     "| ----- | ----- |\n",
     "| [`torch.reshape(input, shape)`](https://pytorch.org/docs/stable/generated/torch.reshape.html#torch.reshape) | Reshapes `input` to `shape` (if compatible), can also use `torch.Tensor.reshape()`. |\n",
-    "| [`torch.Tensor.view(shape)`](https://pytorch.org/docs/stable/generated/torch.Tensor.view.html) | Returns a view of the original tensor in a different `shape` but shares the same data as the original tensor. |\n",
+    "| [`Tensor.view(shape)`](https://pytorch.org/docs/stable/generated/torch.Tensor.view.html) | Returns a view of the original tensor in a different `shape` but shares the same data as the original tensor. |\n",
     "| [`torch.stack(tensors, dim=0)`](https://pytorch.org/docs/1.9.1/generated/torch.stack.html) | Concatenates a sequence of `tensors` along a new dimension (`dim`), all `tensors` must be same size. |\n",
     "| [`torch.squeeze(input)`](https://pytorch.org/docs/stable/generated/torch.squeeze.html) | Squeezes `input` to remove all the dimenions with value `1`. |\n",
     "| [`torch.unsqueeze(input, dim)`](https://pytorch.org/docs/1.9.1/generated/torch.unsqueeze.html) | Returns `input` with a dimension value of `1` added at `dim`. | \n",


### PR DESCRIPTION
In the official documentation, to see a different view of the tensor, you use `Tensor.view(*shape)` but in the notebook, it says `torch.Tensor.view(shape)`.