### PR TITLE
actual out & pred out order in loss function

### DIFF
--- a/01_pytorch_workflow.ipynb
+++ b/01_pytorch_workflow.ipynb
@@ -564,14 +564,6 @@
    "source": [
     "Notice how the values for `weights` and `bias` from `model_0.state_dict()` come out as random float tensors?\n",
     "\n",
-
-    
-    
-    
-    
-    
-    
-    
     "This is because we initialized them above using `torch.randn()`.\n",
     "\n",
     "Essentially we want to start from random parameters and get the model to update them towards parameters that fit our data best (the hardcoded `weight` and `bias` values we set when creating our straight line data).\n",
@@ -2467,18 +2459,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Made changes to the code in training and testing loop. - **documentation of PyTorch loss function says the order should be inputs and then predictions**