### PR TITLE
Fix typo: 'Where can can you get help?' to 'Where can you get help?'

### DIFF
--- a/01_pytorch_workflow.ipynb
+++ b/01_pytorch_workflow.ipynb
@@ -64,7 +64,7 @@
    },
    "source": [
     "\n",
-    "## Where can can you get help?\n",
+    "## Where can you get help?\n",
     "\n",
     "All of the materials for this course are [available on GitHub](https://github.com/mrdbourke/pytorch-deep-learning).\n",
     "\n",
@@ -564,14 +564,6 @@
    "source": [
     "Notice how the values for `weights` and `bias` from `model_0.state_dict()` come out as random float tensors?\n",
     "\n",
-
-    
-    
-    
-    
-    
-    
-    
     "This is because we initialized them above using `torch.randn()`.\n",
     "\n",
     "Essentially we want to start from random parameters and get the model to update them towards parameters that fit our data best (the hardcoded `weight` and `bias` values we set when creating our straight line data).\n",


### PR DESCRIPTION
Fix Typo in '01_pytorch_workflow.ipynb'

Corrected a typo in the file '01_pytorch_workflow.ipynb' where it read "Where can can you get help?" to "Where can you get help?". 

This minor fix improves the clarity of the sentence. Thank you!

