### PR TITLE
Fix Broken Link in PyTorch Custom Datasets Notebook

### DIFF
--- a/04_pytorch_custom_datasets.ipynb
+++ b/04_pytorch_custom_datasets.ipynb
@@ -1788,7 +1788,7 @@
     "\n",
     "But let's try one out ourselves.\n",
     "\n",
-    "Machine learning is all about harnessing the power of randomness and research shows that random transforms (like [`transforms.RandAugment()`](https://pytorch.org/vision/stable/auto_examples/plot_transforms.html#randaugment) and [`transforms.TrivialAugmentWide()`](https://pytorch.org/vision/stable/auto_examples/plot_transforms.html#trivialaugmentwide)) generally perform better than hand-picked transforms.\n",
+    "Machine learning is all about harnessing the power of randomness and research shows that random transforms (like [`transforms.RandAugment()`](https://pytorch.org/vision/stable/auto_examples/transforms/plot_transforms_illustrations.html#randaugment) and [`transforms.TrivialAugmentWide()`](https://pytorch.org/vision/stable/auto_examples/transforms/plot_transforms_illustrations.html#trivialaugmentwide)) generally perform better than hand-picked transforms.\n",
     "\n",
     "The idea behind [TrivialAugment](https://arxiv.org/abs/2103.10158) is... well, trivial. \n",
     "\n",
@@ -4149,13 +4149,18 @@
     "\n",
     "* To practice your knowledge of PyTorch `Dataset`'s and `DataLoader`'s through PyTorch [datasets and dataloaders tutorial notebook](https://pytorch.org/tutorials/beginner/basics/data_tutorial.html).\n",
     "* Spend 10-minutes reading the [PyTorch `torchvision.transforms` documentation](https://pytorch.org/vision/stable/transforms.html).\n",
-    "    * You can see demos of transforms in action in the [illustrations of transforms tutorial](https://pytorch.org/vision/stable/auto_examples/plot_transforms.html#illustration-of-transforms). \n",
+    "    * You can see demos of transforms in action in the [illustrations of transforms tutorial](https://pytorch.org/vision/stable/auto_examples/transforms/plot_transforms_illustrations.html#sphx-glr-auto-examples-transforms-plot-transforms-illustrations-py).\n",
     "* Spend 10-minutes reading the PyTorch [`torchvision.datasets` documentation](https://pytorch.org/vision/stable/datasets.html).\n",
     "    * What are some datasets that stand out to you?\n",
     "    * How could you try building a model on these?\n",
     "* [TorchData is currently in beta](https://pytorch.org/data/beta/index.html) (as of April 2022), it'll be a future way of loading data in PyTorch, but you can start to check it out now. \n",
     "* To speed up deep learning models, you can do a few tricks to improve compute, memory and overhead computations, for more read the post [*Making Deep Learning Go Brrrr From First Principles*](https://horace.io/brrr_intro.html) by Horace He. "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/04_pytorch_custom_datasets.ipynb
+++ b/04_pytorch_custom_datasets.ipynb
@@ -1784,7 +1784,7 @@
     "\n",
     "Training a model on this *artificially* altered dataset hopefully results in a model that is capable of better *generalization* (the patterns it learns are more robust to future unseen examples).\n",
     "\n",
-    "You can see many different examples of data augmentation performed on images using `torchvision.transforms` in PyTorch's [Illustration of Transforms example](https://pytorch.org/vision/stable/auto_examples/plot_transforms.html#illustration-of-transforms).\n",
+    "You can see many different examples of data augmentation performed on images using `torchvision.transforms` in PyTorch's [Illustration of Transforms example](https://pytorch.org/vision/stable/auto_examples/transforms/plot_transforms_illustrations.html#sphx-glr-auto-examples-transforms-plot-transforms-illustrations-py).\n",
     "\n",
     "But let's try one out ourselves.\n",
     "\n",


### PR DESCRIPTION
This pull request addresses the issue reported [here](https://github.com/mrdbourke/pytorch-deep-learning/issues/807). The broken link in the 'PyTorch Custom Datasets'  notebook has been updated with the correct URL.

Updated Link:
[Correct Link](https://pytorch.org/vision/stable/auto_examples/transforms/plot_transforms_illustrations.html#sphx-glr-auto-examples-transforms-plot-transforms-illustrations-py)

Please review the changes and merge if everything is in order.

Thank you,
Lukman