### PR TITLE
Put section number for Section 5 "Equation 2: Multihead Self-Attention (MSA block)"

### DIFF
--- a/video_notebooks/08_pytorch_paper_replicating_video.ipynb
+++ b/video_notebooks/08_pytorch_paper_replicating_video.ipynb
@@ -2500,7 +2500,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## Equation 2: Multihead Self-Attention (MSA block)\n",
+        "## 5. Equation 2: Multihead Self-Attention (MSA block)\n",
         "\n",
         "* **Multihead self-attention** = which part of a sequence should pay the most attention to itself?\n",
         "  * In our case, we have a series of embedded image patches, which patch significantly relates to another patch.\n",


### PR DESCRIPTION
When viewed from an IDE with navigation (e.g. DataSpell) it looked like
```
4. Equation 1: ...
Equation 2: ...
6. Equation 3: ...
```
so I simply added "5." to make it clearer "5. Equation 2: Multihead Self-Attention (MSA block)" is the 5th section