### PR TITLE
Update 00_pytorch_fundamentals.ipynb

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -1521,7 +1521,7 @@
     "| Operation | Calculation | Code |\n",
     "| ----- | ----- | ----- |\n",
     "| **Element-wise multiplication** | `[1*1, 2*2, 3*3]` = `[1, 4, 9]` | `tensor * tensor` |\n",
-    "| **Matrix multiplication** | `[1*1 + 2*2 + 3*3]` = `[14]` | `tensor.matmul(tensor)` |\n"
+    "| **Matrix multiplication** | `[1*1 + 2*2 + 3*3]` = `[14]` | `torch.matmul(tensor)` |\n"
    ]
   },
   {


### PR DESCRIPTION
line 1524,
  "| **Matrix multiplication** | `[1*1 + 2*2 + 3*3]` = `[14]` | `tensor.matmul(tensor)` |\n"

tensor.matmul(tensor) is replaced with torch.matmul(tensor)