### PR TITLE
removed a deprecated method and corrected it accordingly

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -2186,7 +2186,7 @@
     "\n",
     "But there's a fix.\n",
     "\n",
-    "You can change the datatypes of tensors using [`torch.Tensor.type(dtype=None)`](https://pytorch.org/docs/stable/generated/torch.Tensor.type.html) where the `dtype` parameter is the datatype you'd like to use.\n",
+    "You can change the datatypes of tensors using [`tensor = tensor.to(torch.float32)`](https://pytorch.org/docs/stable/generated/torch.Tensor.to.html#torch.Tensor.to) where the torch.float32 is the datatype you'd like to use.\n",
     "\n",
     "First we'll create a tensor and check it's datatype (the default is `torch.float32`)."
    ]


### PR DESCRIPTION
The torch.Tensor.type() method is deprecated. It was used to change the data type of a tensor. However, this method is no longer recommended because it can lead to unexpected results.


Changed the code snippet from using `torch.Tensor.type(dtype=None)` to  `tensor = tensor.to(torch.float32)` for changing the datatype of tensors.  @ line 2189 under the "Change tensor datatype" heading

The link to the documentation has been updated accordingly.