### PR TITLE
Fix typo 07_pytorch_experiment_tracking.ipynb

### DIFF
--- a/07_pytorch_experiment_tracking.ipynb
+++ b/07_pytorch_experiment_tracking.ipynb
@@ -593,7 +593,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Note: This is how a pretrained model would be created in torchvision > 0.13, it will be deprecated in future versions.\n",
+    "# Note: This is how a pretrained model would be created in torchvision < 0.13, it will be deprecated in future versions.\n",
     "# model = torchvision.models.efficientnet_b0(pretrained=True).to(device) # OLD \n",
     "\n",
     "# Download the pretrained weights for EfficientNet_B0\n",


### PR DESCRIPTION
In the sentence: "# Note: This is how a pretrained model would be created in torchvision < 0.13, it will be deprecated in future versions.\n", I have changed the '>' symbol to '<'.

Why:
    x > y means that x is bigger than y.
    x > y means that x is smaller than y.

That typo can confuse the reader.