### PR TITLE
Fix_typo_08_pytorch_paper_replicating.ipynb

### DIFF
--- a/08_pytorch_paper_replicating.ipynb
+++ b/08_pytorch_paper_replicating.ipynb
@@ -2428,7 +2428,7 @@
         "\n",
         "By \"retain positional information\" the authors mean they want the architecture to know what \"order\" the patches come in. As in, patch two comes after patch one and patch three comes after patch two and on and on.\n",
         "\n",
-        "This positional information can be important when considering what's in an image (without positional information an a flattened sequence could be seen as having no order and thus no patch relates to any other patch).\n",
+        "This positional information can be important when considering what's in an image (without positional information and a flattened sequence could be seen as having no order and thus no patch relates to any other patch).\n",
         "\n",
         "To start creating the position embeddings, let's view our current embeddings."
       ]


### PR DESCRIPTION
Fixed a typo changing 'an' by 'and':