### PR TITLE
adding a note about torch.mean

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -2099,6 +2099,8 @@
    "source": [
     "> **Note:** You may find some methods such as `torch.mean()` require tensors to be in `torch.float32` (the most common) or another specific datatype, otherwise the operation will fail. \n",
     "\n",
+    ".mean has an optional parameter called dtype which tells the desired data type of returned tensor and also casts the input tensor to the specified dtype."
+    "\n"
     "You can also do the same as above with `torch` methods."
    ]
   },


### PR DESCRIPTION
dtype can be used to specify the type rather than using typecasting using type(torch.float32)