### PR TITLE
Update 07_pytorch_experiment_tracking.ipynb removed tensorboard.dev related information because of shut down.

### DIFF
--- a/07_pytorch_experiment_tracking.ipynb
+++ b/07_pytorch_experiment_tracking.ipynb
@@ -118,7 +118,7 @@
     "| **1. Get data** | Let's get the pizza, steak and sushi image classification dataset we've been using to try and improve our FoodVision Mini model's results. |\n",
     "| **2. Create Datasets and DataLoaders** | We'll use the `data_setup.py` script we wrote in chapter 05. PyTorch Going Modular to setup our DataLoaders. |\n",
     "| **3. Get and customise a pretrained model** | Just like the last section, 06. PyTorch Transfer Learning we'll download a pretrained model from `torchvision.models` and customise it to our own problem. | \n",
-    "| **4. Train model amd track results** | Let's see what it's like to train and track the training results of a single model using TensorBoard. |\n",
+    "| **4. Train model and track results** | Let's see what it's like to train and track the training results of a single model using TensorBoard. |\n",
     "| **5. View our model's results in TensorBoard** | Previously we visualized our model's loss curves with a helper function, now let's see what they look like in TensorBoard. |\n",
     "| **6. Creating a helper function to track experiments** | If we're going to be adhering to the machine learner practitioner's motto of *experiment, experiment, experiment!*, we best create a function that will help us save our modelling experiment results. |\n",
     "| **7. Setting up a series of modelling experiments** | Instead of running experiments one by one, how about we write some code to run several experiments at once, with different models, different amounts of data and different training times. | \n",
@@ -613,7 +613,7 @@
    "source": [
     "Wonderful!\n",
     "\n",
-    "Now we've got a pretrained model let's turn into a feature extractor model.\n",
+    "Now we've got a pretrained model let's turn it into a feature extractor model.\n",
     "\n",
     "In essence, we'll freeze the base layers of the model (we'll use these to extract features from our input images) and we'll change the classifier head (output layer) to suit the number of classes we're working with (we've got 3 classes: pizza, steak, sushi).\n",
     "\n",
@@ -1034,8 +1034,6 @@
     "| VS Code (notebooks or Python scripts) | Press `SHIFT + CMD + P` to open the Command Palette and search for the command \"Python: Launch TensorBoard\". | [VS Code Guide on TensorBoard and PyTorch](https://code.visualstudio.com/docs/datascience/pytorch-support#_tensorboard-integration) |\n",
     "| Jupyter and Colab Notebooks | Make sure [TensorBoard is installed](https://pypi.org/project/tensorboard/), load it with `%load_ext tensorboard` and then view your results with `%tensorboard --logdir DIR_WITH_LOGS`. | [`torch.utils.tensorboard`](https://pytorch.org/docs/stable/tensorboard.html) and [Get started with TensorBoard](https://www.tensorflow.org/tensorboard/get_started) |\n",
     "\n",
-    "You can also upload your experiments to [tensorboard.dev](https://tensorboard.dev/) to share them publicly with others.\n",
-    "\n",
     "Running the following code in a Google Colab or Jupyter Notebook will start an interactive TensorBoard session to view TensorBoard files in the `runs/` directory.\n",
     "\n",
     "```python\n",
@@ -1068,7 +1066,6 @@
     "\n",
     "> **Note:** For more information on running TensorBoard in notebooks or in other locations, see the following:\n",
     "> * [Using TensorBoard in Notebooks guide by TensorFlow](https://www.tensorflow.org/tensorboard/tensorboard_in_notebooks)\n",
-    "> * [Get started with TensorBoard.dev](https://tensorboard.dev/#get-started) (helpful for uploading your TensorBoard logs to a shareable link)"
    ]
   },
   {
@@ -2306,32 +2303,6 @@
     "<img src=\"https://raw.githubusercontent.com/mrdbourke/pytorch-deep-learning/main/images/07-tensorboard-lowest-test-loss.png\" alt=\"various modelling experiments visualized on tensorboard with model that has the lowest test loss highlighted\" width=900/>\n",
     "\n",
     "*Visualizing the test loss values for the different modelling experiments in TensorBoard, you can see that the EffNetB0 model trained for 10 epochs and with 20% of the data achieves the lowest loss. This sticks with the overall trend of the experiments that: more data, larger model and longer training time is generally better.*\n",
-    "\n",
-    "You can also upload your TensorBoard experiment results to [tensorboard.dev](https://tensorboard.dev) to host them publically for free.\n",
-    "\n",
-    "For example, running code similiar to the following: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# # Upload the results to TensorBoard.dev (uncomment to try it out)\n",
-    "# !tensorboard dev upload --logdir runs \\\n",
-    "#     --name \"07. PyTorch Experiment Tracking: FoodVision Mini model results\" \\\n",
-    "#     --description \"Comparing results of different model size, training data amount and training time.\""
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Running the cell above results in the experiments from this notebook being publically viewable at: https://tensorboard.dev/experiment/VySxUYY7Rje0xREYvCvZXA/\n",
-    "\n",
-    "> **Note:** Beware that anything you upload to tensorboard.dev is publically available for anyone to see. So if you do upload your experiments, be careful they don't contain sensitive information. "
    ]
   },
   {


### PR DESCRIPTION
tensorboard.dev has been shut down as of January 1, 2024. so removed related text and links.

amd -> and

Now we've got a pretrained model let's turn into a feature extractor model. ->
Now we've got a pretrained model let's turn it into a feature extractor model.

print(f"Number of batches of size {BATCH_SIZE} in testing data: {len(train_dataloader_10_percent)} (all experiments will use the same test set)")----->
print(f"Number of batches of size {BATCH_SIZE} in testing data: {len(test_dataloader)} (all experiments will use the same test set)")


