### PR TITLE
Fix the markdown table formating, section model deployement

### DIFF
--- a/09_pytorch_model_deployment.ipynb
+++ b/09_pytorch_model_deployment.ipynb
@@ -242,7 +242,7 @@
     "| API with [FastAPI](https://fastapi.tiangolo.com) | Cloud/self-hosted server |\n",
     "| API with [TorchServe](https://pytorch.org/serve/) | Cloud/self-hosted server | \n",
     "| [ONNX (Open Neural Network Exchange)](https://onnx.ai/index.html) | Many/general |\n",
-    "| Many more... |\n",
+    "| Many more... ||\n",
     "\n",
     "> **Note:** An [application programming interface (API)](https://en.wikipedia.org/wiki/API) is a way for two (or more) computer programs to interact with each other. For example, if your model was deployed as API, you would be able to write a program that could send data to it and then receive predictions back.\n",
     "\n",
@@ -5070,7 +5070,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Hi, 

I notice that the Markdown table formatting is incorrect, section **Ways to deploy a machine learning model**, Notebook **09. PyTorch Model Deployment**.

link to the section: [Ways to deploy a machine learning model](https://www.learnpytorch.io/09_pytorch_model_deployment/#ways-to-deploy-a-machine-learning-model)

I fixed the issue by adding a `|` at the end of the table.

---
![image](https://github.com/mrdbourke/pytorch-deep-learning/assets/116987044/5874ea19-00a5-4be7-ba38-677b8b114cf2)