### PR TITLE
Fixed typo

### DIFF
--- a/docs/00_pytorch_fundamentals.ipynb
+++ b/docs/00_pytorch_fundamentals.ipynb
@@ -1168,7 +1168,7 @@
     "\n",
     "These operations are often a wonderful dance between:\n",
     "* Addition\n",
-    "* Substraction\n",
+    "* Subtraction\n",
     "* Multiplication (element-wise)\n",
     "* Division\n",
     "* Matrix multiplication\n",


### PR DESCRIPTION
This was an eyesore, so I fixed it.

![image](https://github.com/user-attachments/assets/f16d75ad-7ab9-4fbc-9bce-6ac6ed2630e9)
