### PR TITLE
Add dark theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,19 @@ theme:
     - navigation.instant
     - navigation.top
   palette:
-    primary: black
+    # Palette toggle for light mode
+    - scheme: black
+      primary: black
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: black
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 markdown_extensions:
   - meta


### PR DESCRIPTION
Modified the mkdocks.yml file to add a theme toggle button on the top navigation bar. The primary color for the site remains black, however, now the user would be able to view the site in a dark theme.