### PR TITLE
Docs: Update broken link in 01_pytorch_workflow.ipynb

### DIFF
--- a/01_pytorch_workflow.ipynb
+++ b/01_pytorch_workflow.ipynb
@@ -613,7 +613,7 @@
    "source": [
     "Hmm?\n",
     "\n",
-    "You probably noticed we used [`torch.inference_mode()`](https://pytorch.org/docs/stable/generated/torch.inference_mode.html) as a [context manager](https://realpython.com/python-with-statement/) (that's what the `with torch.inference_mode():` is) to make the predictions.\n",
+    "You probably noticed we used [`torch.inference_mode()`](https://docs.pytorch.org/docs/stable/generated/torch.autograd.grad_mode.inference_mode.html) as a [context manager](https://realpython.com/python-with-statement/) (that's what the `with torch.inference_mode():` is) to make the predictions.\n",
     "\n",
     "As the name suggests, `torch.inference_mode()` is used when using a model for inference (making predictions).\n",
     "\n",


### PR DESCRIPTION
Hello,

I found a broken link while going through the documentation of 01_pytorch_workflow part, and i've fixed the broken link in this PR.

Problem:-
The link to pytorch.inference_mode documentation was broken and led to 404 error.

solution :- 
Updated the link of pytorch.inference_mode to its orginial documentation.

files affected :- 01_workflow_pytorch.ipynb