### PR TITLE
docs: fix PyTorch casing and hours formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome to the [Zero to Mastery Learn PyTorch for Deep Learning course](https://
 ## Course materials/outline
 
 * 📖 **Online book version:** All of course materials are available in a readable online book at [learnpytorch.io](https://learnpytorch.io).
-* 🎥 **First five sections on YouTube:** Learn Pytorch in a day by watching the [first 25-hours of material](https://youtu.be/Z_ikDlimN6A).
+* 🎥 **First five sections on YouTube:** Learn Pytorch in a day by watching the [first 25 hours of material](https://youtu.be/Z_ikDlimN6A).
 * 🔬 **Course focus:** code, code, code, experiment, experiment, experiment.
 * 🏃‍♂️ **Teaching style:** [https://sive.rs/kimo](https://sive.rs/kimo).
 * 🤔 **Ask a question:** See the [GitHub Discussions page](https://github.com/mrdbourke/pytorch-deep-learning/discussions) for existing questions/ask your own.


### PR DESCRIPTION
### Changes
- Corrected "Pytorch" → "PyTorch"
- Corrected "25-hours" → "25 hours"

### Why
Improves documentation consistency and readability.

This is a small doc fix. 
