### PR TITLE
docs: Correct typo in walk_through_dir docstring (#1250)

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -28,7 +28,7 @@ def walk_through_dir(dir_path):
 
     Returns:
     A print out of:
-      number of subdiretories in dir_path
+      number of subdirectories in dir_path
       number of images (files) in each subdirectory
       name of each subdirectory
     """


### PR DESCRIPTION
### Description

This pull request addresses the typo found in the `walk_through_dir` function's docstring within `helper_functions.py`. The word "subdiretories" has been corrected to "subdirectories".

### Related Issue

Closes #1250

### Checklist:

- [x] I have read the [CONTRIBUTING.md](link-to-contributing-guide-if-available) file.
- [x] My code follows the project's style guidelines.
- [x] My changes are focused on a single issue.
- [x] I have double-checked my changes for any additional typos.