### PR TITLE
Add missing directory creation step for going_modular

### DIFF
--- a/05_pytorch_going_modular.md
+++ b/05_pytorch_going_modular.md
@@ -246,7 +246,16 @@ data/
 
 Once we've got data, we can then turn it into PyTorch `Dataset`'s and `DataLoader`'s (one for training data and one for testing data).
 
-We convert the useful `Dataset` and `DataLoader` creation code into a function called `create_dataloaders()`.
+First, we need to create the `going_modular` directory where we'll save all our Python scripts:
+
+```python
+import os
+
+# Create the directory if it doesn't exist
+os.makedirs('going_modular', exist_ok=True)
+```
+
+Now we can convert the useful `Dataset` and `DataLoader` creation code into a function called `create_dataloaders()`.
 
 And we write it to file using the line `%%writefile going_modular/data_setup.py`. 
 


### PR DESCRIPTION
This PR fixes a missing step in the PyTorch going modular documentation where the going_modular directory needs to be created before writing Python scripts to it.

## Changes
- Added os.makedirs step before the first %%writefile command in section 2
- Ensures going_modular directory exists before attempting to write data_setup.py
- Prevents FileNotFoundError when users follow the notebook instructions

## Impact
Users can now successfully follow the notebook without encountering directory creation errors when the %%writefile commands execute.