### PR TITLE
fix: run model in eval mode with inference_mode for predictions in ce…

### DIFF
--- a/02_pytorch_classification.ipynb
+++ b/02_pytorch_classification.ipynb
@@ -82,7 +82,7 @@
    "source": [
     "## Where can you get help?\n",
     "\n",
-    "All of the materials for this course [live on GitHub](https://github.com/mrdbourke/pytorch-deep-learning).\n",
+    "All of the materials for this course [live on GitHub](https://github.com/mrdbourke/pytorch-deep-learning). \n",
     "\n",
     "And if you run into trouble, you can ask a question on the [Discussions page](https://github.com/mrdbourke/pytorch-deep-learning/discussions) there too.\n",
     "\n",
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -912,7 +912,9 @@
    ],
    "source": [
     "# Make predictions with the model\n",
-    "untrained_preds = model_0(X_test.to(device))\n",
+    "model_0.eval()\n",
+    "with torch.inference_mode():\n",
+    "  untrained_preds = model_0(X_test.to(device))\n",
     "print(f\"Length of predictions: {len(untrained_preds)}, Shape: {untrained_preds.shape}\")\n",
     "print(f\"Length of test samples: {len(y_test)}, Shape: {y_test.shape}\")\n",
     "print(f\"\\nFirst 10 predictions:\\n{untrained_preds[:10]}\")\n",


### PR DESCRIPTION
### What was changed
- Updated cell 13 in `02_pytorch_classification.ipynb` to:
  - Set the model to `eval()` mode before prediction
  - Wrap prediction code with `torch.inference_mode()`

### Why this change
Previously, predictions were made while the model was still in training mode and gradients were tracked, which could lead to:
- Inconsistent outputs during inference
- Unnecessary memory and compute usage

By setting the model to evaluation mode and using `inference_mode`, predictions are now:
- Consistent with expected inference behavior
- More efficient (no gradient tracking)
