### PR TITLE
Fix broken Wikipedia link in Resources section of 00_pytorch_fundamentals.ipynb

### DIFF
--- a/00_pytorch_fundamentals.ipynb
+++ b/00_pytorch_fundamentals.ipynb
@@ -1012,7 +1012,7 @@
     "\n",
     "> **Resources:** \n",
     "  * See the [PyTorch documentation for a list of all available tensor datatypes](https://pytorch.org/docs/stable/tensors.html#data-types).\n",
-    "  * Read the [Wikipedia page for an overview of what precision in computing](https://en.wikipedia.org/wiki/Precision_(computer_science)) is.\n",
+    "  * Read the [Wikipedia page for an overview of what precision in computing](<https://en.wikipedia.org/wiki/Precision_(computer_science)>) is.\n",
     "\n",
     "Let's see how to create some tensors with specific datatypes. We can do so using the `dtype` parameter."
    ]


### PR DESCRIPTION
This PR fixes the broken Wikipedia link under the Resources section in `00_pytorch_fundamentals.ipynb`.

- The link to the Wikipedia page on precision in computing was not working correctly because the closing ) wasn’t included in the markdown.

- Updated the markdown so the link now correctly points to the full Wikipedia page.

Linked Issue:
Fixes #1268