### PR TITLE
Update notebook format and widget state

### DIFF
--- a/extras/solutions/09_pytorch_model_deployment_exercise_solutions.ipynb
+++ b/extras/solutions/09_pytorch_model_deployment_exercise_solutions.ipynb
@@ -2884,6 +2884,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "1578fb055b2b409a9a66b07471aa21c3": {
+"state": {
      "model_module": "@jupyter-widgets/base",
      "model_module_version": "1.2.0",
      "model_name": "LayoutModel",
@@ -5962,6 +5963,9 @@
      }
     }
    }
+ },
+    "version_major": 2,
+    "version_minor": 0
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Without that the notebook is not rendering and shows error:
Invalid Notebook There was an error rendering your Notebook: the 'state' key is missing from 'metadata.widgets'. Add 'state' to each, or remove 'metadata.widgets'. Using nbformat v5.10.4 and nbconvert v7.16.6