### PR TITLE
Fix typo: BECWithLogitsLoss → BCEWithLogitsLoss

### DIFF
--- a/video_notebooks/02_pytorch_classification_video.ipynb
+++ b/video_notebooks/02_pytorch_classification_video.ipynb
@@ -1133,7 +1133,7 @@
         "And for optimizers, two of the most common and useful are SGD and Adam, however PyTorch has many built-in options.\n",
         "\n",
         "* For some common choices of loss functions and optimizers - https://www.learnpytorch.io/02_pytorch_classification/#21-setup-loss-function-and-optimizer\n",
-        "* For the loss function we're going to use `torch.nn.BECWithLogitsLoss()`, for more on what binary cross entropy (BCE) is, check out this article - https://towardsdatascience.com/understanding-binary-cross-entropy-log-loss-a-visual-explanation-a3ac6025181a \n",
+        "* For the loss function we're going to use `torch.nn.BCEWithLogitsLoss()`, for more on what binary cross entropy (BCE) is, check out this article - https://towardsdatascience.com/understanding-binary-cross-entropy-log-loss-a-visual-explanation-a3ac6025181a \n",
         "* For a defintion on what a logit is in deep learning - https://stackoverflow.com/a/52111173/7900723 \n",
         "* For different optimizers see `torch.optim`"
       ],


### PR DESCRIPTION
BEC was incorrectly written instead of BCE (Binary Cross Entropy)